### PR TITLE
Feature/adding cross account support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ All notable changes to this project will be documented in this file.
 - Enhanced lifecycle policy configuration
 - Registry replication support
 
+## [0.0.2] - 2024-10-14
+
+### Added
+
+- Added cross account ECR policy access.
+- Added `ecr_cross_account_access` `ecr_cross_account_number` `ecr_cross_account_region`
+
+---
+
+
 ## [0.0.1] - 2023-07-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,6 +13,21 @@ A Terraform module for managing an AWS ECR Repository.
 ## Requirements
 
 - An existing AWS Account
+
+Example usage with Cross Account access
+```terraform
+
+module "ecr_repository" {
+  source                              = TO BE UPDATED
+  ecr_repo_name                       = "ecr-test-policy-std"
+  ecr_force_delete                    = true
+  ecr_tagged_max_images               = 7
+  ecr_cross_account_number = "222222222222"
+  ecr_cross_account_access = true
+}
+```
+Above, this ECR repository made in AWS account 11111111111 will allow AWS account 222222222222 to retrieve the image from ECR.
+
 <!-- BEGIN_TF_DOCS -->
 ## Providers
 

--- a/README.md
+++ b/README.md
@@ -45,11 +45,15 @@ No modules.
 |------|------|
 | [aws_ecr_lifecycle_policy.lifecycle_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_lifecycle_policy) | resource |
 | [aws_ecr_repository.ecr_repo](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
+| [aws_ecr_repository_policy.ecr_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_policy) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_ecr_cross_account_access"></a> [ecr\_cross\_account\_access](#input\_ecr\_cross\_account\_access) | Allows for letting another AWS account access your ECR policy using ECR Policy rules | `bool` | `false` | no |
+| <a name="input_ecr_cross_account_number"></a> [ecr\_cross\_account\_number](#input\_ecr\_cross\_account\_number) | AWS account that will be granted access to ECR | `string` | `""` | no |
+| <a name="input_ecr_cross_account_region"></a> [ecr\_cross\_account\_region](#input\_ecr\_cross\_account\_region) | AWS account that will be granted access to ECR's region | `string` | `"us-east-1"` | no |
 | <a name="input_ecr_encryption_configuration"></a> [ecr\_encryption\_configuration](#input\_ecr\_encryption\_configuration) | The encryption type to use for the repository. Valid values are AES256 or KMS. Defaults to AES256. If using KMS, provide the KMS key ARN. | <pre>object({<br>    encryption_type = string<br>    kms_key         = string<br>  })</pre> | <pre>{<br>  "encryption_type": "AES256",<br>  "kms_key": null<br>}</pre> | no |
 | <a name="input_ecr_force_delete"></a> [ecr\_force\_delete](#input\_ecr\_force\_delete) | If true, will delete the repository even if it contains images. Defaults to false. | `bool` | `false` | no |
 | <a name="input_ecr_lifecycle_prefix_list"></a> [ecr\_lifecycle\_prefix\_list](#input\_ecr\_lifecycle\_prefix\_list) | The lifecycle rule expires images with this list of prefixes based on the ecr\_max\_images variable. Defaults to semver. | `list(string)` | <pre>[<br>  "0",<br>  "1",<br>  "2"<br>]</pre> | no |

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Example usage with Cross Account access
 ```terraform
 
 module "ecr_repository" {
-  source                              = TO BE UPDATED
-  ecr_repo_name                       = "ecr-test-policy-std"
-  ecr_force_delete                    = true
-  ecr_tagged_max_images               = 7
+  source                   = TO BE UPDATED
+  ecr_repo_name            = "ecr-test-policy-std"
+  ecr_force_delete         = true
+  ecr_tagged_max_images    = 7
   ecr_cross_account_number = "222222222222"
   ecr_cross_account_access = true
 }

--- a/ecr-policy.tf
+++ b/ecr-policy.tf
@@ -3,6 +3,11 @@ resource "aws_ecr_repository_policy" "ecr_policy" {
   count       = var.ecr_cross_account_access ? 1 : 0
   repository =  var.ecr_repo_name
 
+  depends_on = [
+    aws_ecr_repository.ecr_repo
+  ]
+
+
   policy = jsonencode({
     Version = "2008-10-17"
     Statement = [

--- a/ecr-policy.tf
+++ b/ecr-policy.tf
@@ -1,7 +1,7 @@
 
 resource "aws_ecr_repository_policy" "ecr_policy" {
-  count       = var.ecr_cross_account_access ? 1 : 0
-  repository =  var.ecr_repo_name
+  count      = var.ecr_cross_account_access ? 1 : 0
+  repository = var.ecr_repo_name
 
   depends_on = [
     aws_ecr_repository.ecr_repo

--- a/ecr-policy.tf
+++ b/ecr-policy.tf
@@ -1,0 +1,41 @@
+
+resource "aws_ecr_repository_policy" "ecr_policy" {
+  count       = var.ecr_cross_account_access ? 1 : 0
+  repository =  var.ecr_repo_name
+
+  policy = jsonencode({
+    Version = "2008-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+        Action = [
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:BatchCheckLayerAvailability"
+        ]
+        Condition = {
+          StringLike = {
+            "aws:SourceArn" = "arn:aws:lambda:${ecr_cross_account_region}:${var.ecr_cross_account_number}:function:*"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${var.ecr_cross_account_number}:root"
+
+        }
+        Action = [
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:BatchCheckLayerAvailability"
+        ]
+      }
+    ]
+  })
+}
+
+

--- a/ecr-policy.tf
+++ b/ecr-policy.tf
@@ -18,7 +18,7 @@ resource "aws_ecr_repository_policy" "ecr_policy" {
         ]
         Condition = {
           StringLike = {
-            "aws:SourceArn" = "arn:aws:lambda:${ecr_cross_account_region}:${var.ecr_cross_account_number}:function:*"
+            "aws:SourceArn" = "arn:aws:lambda:${var.ecr_cross_account_region}:${var.ecr_cross_account_number}:function:*"
           }
         }
       },

--- a/variables.tf
+++ b/variables.tf
@@ -65,7 +65,7 @@ variable "ecr_cross_account_access" {
 variable "ecr_cross_account_number" {
   type        = string
   description = "AWS account that will be granted access to ECR"
-  default     = "222222222222"
+  default     = ""
 }
 
 variable "ecr_cross_account_region" {

--- a/variables.tf
+++ b/variables.tf
@@ -55,3 +55,21 @@ variable "ecr_tagged_max_images" {
   description = "The maximum number of images to keep in the ECR repository."
   default     = 50
 }
+
+variable "ecr_cross_account_access" {
+  type        = bool
+  description = "Allows for letting another AWS account access your ECR policy using ECR Policy rules"
+  default     = false
+}
+
+variable "ecr_cross_account_number" {
+  type        = string
+  description = "AWS account that will be granted access to ECR"
+  default     = ""
+}
+
+variable "ecr_cross_account_region" {
+  type        = string
+  description = "AWS account that will be granted access to ECR's region"
+  default     = "us-east-1"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -65,7 +65,7 @@ variable "ecr_cross_account_access" {
 variable "ecr_cross_account_number" {
   type        = string
   description = "AWS account that will be granted access to ECR"
-  default     = ""
+  default     = "222222222222"
 }
 
 variable "ecr_cross_account_region" {


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Adding functionality for Cross Account ECR access via ECR policy.  

## Why is this PR being done?
So that you can define access to your ECR repo to another of your accounts.  This way the image can remain private and be accessed by a remote account.  

## Checklist - These are **not** mandatory

- [x] I have updated the README.md if there are new procedures or changes.
- [x] I have updated CHANGELOG.md with new changes. 
- [x] I have deployed this change in another project successfully.

## Optional: Additional Notes
